### PR TITLE
fix ZiggeoConnect#request when creating authtoken

### DIFF
--- a/lib/classes/ZiggeoConnect.rb
+++ b/lib/classes/ZiggeoConnect.rb
@@ -16,12 +16,12 @@ class ZiggeoConnect
     elsif (method == "POST")
       req = Net::HTTP::Post.new(url.to_s)
       if (data != nil)
-      req.req.set_form_data(data)
+      req.set_form_data(data)
       end
     elsif (method == "DELETE")
       req = Net::HTTP::Delete.new(url.to_s)
       if (data != nil)
-      req.req.set_form_data(data)
+      req.set_form_data(data)
       end
     end
     req.basic_auth(@application.token, @application.private_key)


### PR DESCRIPTION
Fixes error when trying to create a new authtoken.

e.g.
Ziggeo.new('app token','private key', 'enc key').authtokens.create(['create'])

Error thrown:
NoMethodError: undefined method `req' for #<Net::HTTP::Post POST>
    from /home/rogeliosevilla1/.rvm/gems/ruby-2.0.0-p598@myproject/gems/Ziggeo-1.0/lib/classes/ZiggeoConnect.rb:19:in`request'
    from /home/rogeliosevilla1/.rvm/gems/ruby-2.0.0-p598@myproject/gems/Ziggeo-1.0/lib/classes/ZiggeoConnect.rb:40:in `requestJSON'
    from /home/rogeliosevilla1/.rvm/gems/ruby-2.0.0-p598@myproject/gems/Ziggeo-1.0/lib/classes/ZiggeoConnect.rb:56:in`postJSON'
    from /home/rogeliosevilla1/.rvm/gems/ruby-2.0.0-p598@myproject/gems/Ziggeo-1.0/lib/classes/ZiggeoAuthtokens.rb:20:in `create'
