### PR TITLE
Allow httparty version to be >= 0.13.0 and < 1.0.0.

### DIFF
--- a/ziggeo.gemspec
+++ b/ziggeo.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "README.md"]
   s.require_paths = ["lib"]
   s.license     = 'Apache-2.0'
-  s.add_dependency 'httparty', '~> 0.13.5'
+  s.add_dependency 'httparty', '~> 0.13'
   s.add_dependency 'httmultiparty'
 end


### PR DESCRIPTION
Previously the httparty version constraint was >= 0.13.5 and < 0.14.0.

We encountered an issue in a project that requires httparty > 0.15 - which conflicts with the httparty version constraint that ZiggeoRubySdk had specified.